### PR TITLE
Revise kernel_sizes.py

### DIFF
--- a/kernel_sizes.py
+++ b/kernel_sizes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Credit: Robert Maynard <rmaynard@nvidia.com>
+#         Jinsol Park <jinsolp@nvidia.com>
+#         Hyunsu Cho <phcho@nvidia.com>
 
 import argparse
 import os
@@ -22,164 +25,233 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from collections import defaultdict
 
-def execute(command,args, **kwargs):
-  working_dir = kwargs.get('cwd', None)
-  try:
-    invoke = [command]
-    invoke += args
-    output = subprocess.run(invoke, cwd=working_dir,check=True, capture_output=True).stdout
-    output = output.splitlines()
-  except (OSError, subprocess.CalledProcessError) as err:
-    print(err)
-    output = []
-  return output
+
+def tidy_kernel_name(x):
+    # Tokenize
+    tokens = []
+    current_token = ""
+    skip_space = False
+    for c in x:
+        if c in ("<", ">", "(", ")", ","):
+            if current_token:
+                tokens.append(current_token)
+            tokens.append(c)
+            current_token = ""
+            skip_space = False
+        elif c.isspace():
+            if not skip_space:
+                current_token += c
+        else:
+            current_token += c
+            skip_space = False
+
+        if c == ",":
+            # Skip space(s) after comma
+            skip_space = True
+    if current_token:
+        tokens.append(current_token)
+
+    # Print tokens with indents and line breaks
+    out = ""
+    indent = 0
+    for token in tokens:
+        if token in ("<", "("):
+            out += f"{token}\n"
+            indent += 2
+            out += " " * indent
+        elif token in (">", ")"):
+            indent -= 2
+            out += "\n"
+            out += " " * indent
+            out += token
+        elif token == ",":
+            out += ",\n"
+            out += " " * indent
+        else:
+            out += token
+    return out
+
+
+def execute(command, args, **kwargs):
+    working_dir = kwargs.get("cwd", None)
+    try:
+        invoke = [command]
+        invoke += args
+        output = subprocess.run(
+            invoke, cwd=working_dir, check=True, capture_output=True
+        ).stdout
+        output = output.splitlines()
+    except (OSError, subprocess.CalledProcessError) as err:
+        print(err)
+        output = []
+    return output
+
 
 def is_elf(file_path: str) -> bool:
-    with open(file_path, 'rb') as f:
-      first_byte = f.read(4)
-      return first_byte == b'\x7fELF'
+    with open(file_path, "rb") as f:
+        first_byte = f.read(4)
+        return first_byte == b"\x7fELF"
+
 
 def extract_cubins(elf_file: str, dump_location: str):
-  execute("cuobjdump", ["--extract-elf", "all", os.path.abspath(elf_file)], cwd=dump_location)
-  files = os.listdir(dump_location)
-  return [ os.path.join(dump_location, f) for f in files ]
+    execute(
+        "cuobjdump",
+        ["--extract-elf", "all", os.path.abspath(elf_file)],
+        cwd=dump_location,
+    )
+    files = os.listdir(dump_location)
+    return [os.path.join(dump_location, f) for f in files]
+
 
 class Symbol:
-  def __init__(self, name, raw_type, str_size) -> None:
+    def __init__(self, name, raw_type, str_size) -> None:
+        self.type = raw_type
+        self.name = name
+        self.size = int(str_size)
 
-    self.type = raw_type
-    self.name = name
-    self.size = int(str_size)
+    def __eq__(self, other):
+        return self.name == other.name and self.type == other.type
 
-  def __eq__(self, other):
-    return self.name == other.name
-
-  def __str__(self):
-    return self.name
 
 def extract_info_from_cubin(file: str):
-  # Each entry for a symbol has the format "type.<symbol>"
-  # we abuse the fact that the symbols will start with an `_`
-  # to construct an unique id that allows us to ignore
-  # info lines
-  regex = re.compile(r"\s+|\._")
-  output = execute("size", ["-A",  file])
-  nice_symbols = []
-  for line in output:
-     raw_text = line.decode('utf8')
-     entry = regex.split(raw_text)
-     if len(entry) == 4:
-        nice_symbols.append(Symbol("_"+entry[1], entry[0], entry[2]))
-  return nice_symbols
+    # Each entry for a symbol has the format "type.<symbol>"
+    # we abuse the fact that the symbols will start with an `_`
+    # to construct an unique id that allows us to ignore
+    # info lines
+    regex = re.compile(r"\s+|\._")
+    output = execute("size", ["-A", file])
+    nice_symbols = []
+    for line in output:
+        raw_text = line.decode("utf8")
+        entry = regex.split(raw_text)
+        if len(entry) == 4:
+            nice_symbols.append(Symbol("_" + entry[1], entry[0], entry[2]))
+    return nice_symbols
 
 
 def transform_to_demangled_names(symbols):
-  # Call cu++filt with a subset of entries to save time
-  # We can't pass all entries as cu++filt has a max
-  # input size
-  def chunk_iter(list):
-    for i in range(0, len(list), 128):
-        yield list[i:i + 128]
+    # Call llvm-cxxfilt with a subset of entries to save time
+    # We can't pass all entries as llvm-cxxfilt has a max
+    # input size
+    def chunk_iter(x):
+        for i in range(0, len(x), 128):
+            yield x[i : i + 128]
 
-  all_names = list(symbols.keys())
-  all_sizes = list(symbols.values())
-  symbols_out = {}
-  for names,sizes in zip(chunk_iter(all_names), chunk_iter(all_sizes)):
-    names = [n.decode('utf8') for n in execute("c++filt", names)]
-    for n,s in zip(names,sizes):
-      symbols_out[n]=s
+    symbols_out = []
+    # Process 128 symbols at a time
+    for chunk in chunk_iter(symbols):
+        demangled = [
+            n.decode("utf8") for n in execute("llvm-cxxfilt", [s.name for s in chunk])
+        ]
+        for i, n in enumerate(demangled):
+            symbols_out.append(Symbol(n, chunk[i].type, chunk[i].size))
 
-  return symbols_out
+    return symbols_out
 
 
 class SymbolCache:
 
-  def __init__(self, inclusions) -> None:
-    self.has_inclusions = False
-    if inclusions:
-      # build regex engines
-      self.inclusions = [ re.compile(e) for e in inclusions ]
-      self.has_inclusions = True
-    self.cubin_cache = {}
-    self.tmpdir = tempfile.mkdtemp()
+    def __init__(self, inclusions) -> None:
+        self.has_inclusions = False
+        if inclusions:
+            # build regex engines
+            self.inclusions = [re.compile(e) for e in inclusions]
+            self.has_inclusions = True
+        self.cubin_cache = {}
+        self.tmpdir = tempfile.mkdtemp()
 
-  def __del__(self):
-    if self.tmpdir:
-      shutil.rmtree(self.tmpdir)
+    def __del__(self):
+        if self.tmpdir:
+            shutil.rmtree(self.tmpdir)
 
-  def load(self, path) -> None:
-    if path not in self.cubin_cache and is_elf(path):
-      dump_loc = os.path.join(self.tmpdir, os.path.basename(path))
-      os.mkdir( dump_loc )
-      cubins = extract_cubins(path, dump_loc)
-      self.cubin_cache[path] = cubins
+    def load(self, path) -> None:
+        if path not in self.cubin_cache and is_elf(path):
+            dump_loc = os.path.join(self.tmpdir, os.path.basename(path))
+            os.mkdir(dump_loc)
+            cubins = extract_cubins(path, dump_loc)
+            self.cubin_cache[path] = cubins
 
-  def display_sizes(self):
-    def add_or_update(json, symbol):
-      if symbol.name in json:
-        json[symbol.name] += symbol.size
-      else:
-        json[symbol.name] = symbol.size
+    def display_sizes(self):
+        # Determine if a name matches any of the inclusions regex
+        def has_match(name):
+            if self.has_inclusions:
+                for regex in self.inclusions:
+                    if regex.search(name):
+                        return True
+                return False
+            return True
 
-    # determine if a name matches any of the inclusions regex
-    def has_match(name, inclusions):
-      for regex in inclusions:
-        if regex.search(name) :
-          return True
-      return False
+        sizes = defaultdict(int)
+        counts = defaultdict(int)
+        symbols = []
+        # When counting the number of duplication for each kernel,
+        # ignore the presence of multiple code section types
+        # (.text, .constant, .nv.info etc).
+        for values in self.cubin_cache.values():
+            for cubin in values:
+                current_symbols = transform_to_demangled_names(
+                    extract_info_from_cubin(cubin)
+                )
+                symbols.extend(current_symbols)
+                for s in current_symbols:
+                    if has_match(s.name):
+                        sizes[s.name] += s.size
+                        counts[(s.name, s.type)] += 1
 
-    entries = {}
-    for values in self.cubin_cache.values():
-      for cubin in values:
-        symbols = extract_info_from_cubin(cubin)
-        for s in symbols:
-          add_or_update(entries, s)
+        # counts_agg[symbol_name] <- max(counts[(symbol_name, *)])
+        counts_agg = defaultdict(int)
+        for k, v in counts.items():
+            counts_agg[k[0]] = max(counts_agg[k[0]], v)
 
-    entries = transform_to_demangled_names(entries)
+        total_size = sum(sizes.values())
+        entries = {k: (sizes[k], v) for k, v in counts_agg.items()}
 
-    # apply the regex filters
-    if self.has_inclusions:
-      entries = {k:v for k,v in entries.items() if has_match(k, self.inclusions) }
-
-    total_size = 0
-    for e in entries.values():
-      total_size += e
-
-    for k, v in sorted(entries.items(), key=lambda kv: kv[1]):
-      print("%s: %s bytes" % (k,v))
-    print("Total uncompressed size of CUDA kernels: ", total_size, "bytes")
+        for k, v in sorted(entries.items(), key=lambda kv: kv[1][0]):
+            if v[0] > 0:  # Skip zero-byte entries
+                print(f"{tidy_kernel_name(k)}: {v[0]} bytes ({v[1]} instantiations)\n")
+        print("Total uncompressed size of CUDA kernels: ", total_size, "bytes")
 
 
 def main():
-  parser = argparse.ArgumentParser(prog='report CUDA SASS Kernel sizes')
-  parser.add_argument("-i", "--include", type=str, nargs='+', help="only include symbols that match this pattern ( applied on demangled names)")
-  parser.add_argument("input", nargs='+', type=str, help="elf file ( .so, .exe, .o ) or directory")
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser(prog="report CUDA SASS Kernel sizes")
+    parser.add_argument(
+        "-i",
+        "--include",
+        type=str,
+        nargs="+",
+        help="only include symbols that match this pattern ( applied on demangled names)",
+    )
+    parser.add_argument(
+        "input", nargs="+", type=str, help="elf file ( .so, .exe, .o ) or directory"
+    )
+    args = parser.parse_args()
 
-  cache = SymbolCache(args.include)
+    cache = SymbolCache(args.include)
 
-  # Transform any directory into files
-  items = []
-  for item in args.input:
-    if os.path.isdir(item):
-      for possible_item in os.listdir(item):
-        pitem = os.path.join(item, possible_item)
-        if os.path.isfile(pitem):
-          items.append(pitem)
-    else:
-      items.append(item)
+    # Transform any directory into files
+    items = []
+    for item in args.input:
+        if os.path.isdir(item):
+            for possible_item in os.listdir(item):
+                pitem = os.path.join(item, possible_item)
+                if os.path.isfile(pitem):
+                    items.append(pitem)
+        else:
+            items.append(item)
 
-  for item in items:
-    if os.path.isfile(item):
-      cache.load(item)
+    for item in items:
+        if os.path.isfile(item):
+            cache.load(item)
 
-  if len(cache.cubin_cache) == 0:
-    print("Invalid input given")
-    parser.print_help()
-    sys.exit(1)
+    if len(cache.cubin_cache) == 0:
+        print("Invalid input given")
+        parser.print_help()
+        sys.exit(1)
 
-  cache.display_sizes()
+    cache.display_sizes()
 
-if __name__ == '__main__':
-  main()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Format long kernel names with indentation
* Use `llvm-cxxfilt` for better legibility and ability to parse variadic templates
* Count the number of distinct TUs that contain each kernel. Previously, the kernel was counted multiple times per TU, since CUBIN dump lists multiple entries per kernel.
* Re-format the script using `black` and `isort`.
* Exclude kernels whose size is zero.