### PR TITLE
Configure `/merge` + require CI & approvals

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,9 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+auto_merger: true
+branch_checker: false
+label_checker: false
+release_drafter: false
+forward_merger: false
+merge_barriers: true


### PR DESCRIPTION
Follow up on issue https://github.com/rapidsai/build-planning/issues/251

Enable `/merge` and require CI & approvals.